### PR TITLE
Allow fetching docs by version, branch name, SHA, or local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,17 @@ npm install electron-docs --save
 
 ## Programmatic Usage
 
-Require it and invoke the function with no arguments:
+Require the function and call it with any of the following:
+
+- A remote branch name, like `master`
+- A version number, like `1.4.4`
+- A commit SHA, like `76375a83eb3a97e7aed14d37d8bdc858c765e564`
+- A local directory, like `~/my/path/to/electron/`
 
 ```js
 const electronDocs = require('electron-docs')
 
-electronDocs().then(function(docs) {
+electronDocs('master').then(function(docs) {
   // docs is an array of objects, one for each markdown file in /docs
 })
 ```
@@ -34,16 +39,7 @@ Each object in the `docs` array looks like this:
 }
 ```
 
-The latest version of Electron is fetched by default. If you need a different
-version, specify it as the first argument:
-
-```js
-electronDocs('1.2.0').then(function(docs) {
-  // ...
-})
-```
-
-You can also point to a local directory instead of downloading a tarball:
+When fetching docs from a local directory, be sure to use a full path:
 
 ```js
 const path = require('path')
@@ -56,12 +52,6 @@ electronDocs(docsPath).then(function(docs) {
 If you prefer node-style callbacks instead of promises, those are supported too:
 
 ```js
-// latest
-electronDocs(function(err, docs) {
-  console.log(err, docs)
-})
-
-// a specific version
 electronDocs('1.0.0', function(err, docs) {
   console.log(err, docs)
 })
@@ -92,19 +82,19 @@ npm i && npm t
 
 ## Dependencies
 
-- [bluebird](https://github.com/petkaantonov/bluebird): Full featured Promises/A+ implementation with exceptionally good performance
-- [github-latest-release](https://github.com/chentsulin/github-latest-release): Get latest release information from github repository
-- [got](https://github.com/sindresorhus/got): Simplified HTTP requests
+- [got](https://ghub.io/got): Simplified HTTP requests
 - [gunzip-maybe](https://github.com/mafintosh/gunzip-maybe): Transform stream that gunzips its input if it is gzipped and just echoes it if not
-- [node-dir](https://github.com/fshost/node-dir): asynchronous file and directory operations for Node.js
-- [ora](https://github.com/sindresorhus/ora): Elegant terminal spinner
+- [node-dir](https://ghub.io/node-dir): asynchronous file and directory operations for Node.js
+- [ora](https://ghub.io/ora): Elegant terminal spinner
+- [path-exists](https://ghub.io/path-exists): Check if a path exists
+- [pify](https://github.com/sindresorhus/pify): Promisify a callback-style function
+- [semver](https://ghub.io/semver): The semantic version parser used by npm.
 - [tar-fs](https://github.com/mafintosh/tar-fs): filesystem bindings for tar-stream
 
 ## Dev Dependencies
 
 - [tap-spec](https://github.com/scottcorgan/tap-spec): Formatted TAP output like Mocha&#39;s spec reporter
 - [tape](https://github.com/substack/tape): tap-producing test harness for node and browsers
-
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -82,4 +82,4 @@ function readLocalFiles (directory, callback) {
     })
 }
 
-module.exports = require('bluebird').promisify(docs)
+module.exports = require('pify')(docs)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path')
 const got = require('got')
 const dir = require('node-dir')
 const tar = require('tar-fs')
-const exists = require('path-exists').sync
+const pathExists = require('path-exists').sync
 const gunzip = require('gunzip-maybe')
 const latestRelease = require('github-latest-release')
 const semver = require('semver')
@@ -11,11 +11,7 @@ const semver = require('semver')
 function readAllDocFiles (rootAPIDocsPath, callback) {
   readLocalFiles(rootAPIDocsPath, (err, files) => {
     if (err) return callback(err)
-    if (!fs.existsSync(path.resolve(rootAPIDocsPath, 'structures'))) return callback(null, files)
-    readLocalFiles(path.resolve(rootAPIDocsPath, 'structures'), (structErr, structFiles) => {
-      if (structErr) return callback(structErr)
-      callback(null, files.concat(structFiles))
-    })
+    callback(null, files)
   })
 }
 
@@ -30,7 +26,7 @@ function docs (version, callback) {
   } else if (semver.valid(version)) {
     // download specified version number
     download(version, callback)
-  } else if (exists(version)) {
+  } else if (pathExists(version)) {
     // version is a local directory
     readAllDocFiles(version, callback)
   } else {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.4.0",
     "github-latest-release": "^0.1.1",
     "got": "^6.3.0",
     "gunzip-maybe": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "license": "MIT",
   "dependencies": {
-    "github-latest-release": "^0.1.1",
     "got": "^6.3.0",
     "gunzip-maybe": "^1.3.1",
     "node-dir": "^0.1.12",
     "ora": "^0.2.3",
     "path-exists": "^3.0.0",
+    "pify": "^2.3.0",
     "semver": "^5.1.0",
     "tar-fs": "^1.13.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -4,10 +4,10 @@ const semver = require('semver')
 const electronDocs = require('..')
 
 test('electronDocs', {timeout: 30 * 1000}, function (t) {
-  t.plan(10)
+  t.plan(11)
 
-  electronDocs().then(function (docs) {
-    t.comment('default to latest version')
+  electronDocs('master').then(function (docs) {
+    t.comment('fetch by branch name')
     t.ok(docs.length > 0, 'docs is a non-empty array')
     t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
     t.ok(docs.every(doc => doc.slug.length > 0), 'every doc has a slug property')
@@ -15,19 +15,19 @@ test('electronDocs', {timeout: 30 * 1000}, function (t) {
   })
 
   electronDocs('1.2.0').then(function (docs) {
-    t.comment('specific version')
+    t.comment('fetch by version number')
     var doc = docs[0]
     t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
   })
 
-  // electronDocs('76375a83eb3a97e7aed14d37d8bdc858c765e564').then(function (docs) {
-  //   t.comment('commit SHA')
-  //   var doc = docs[0]
-  //   t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
-  // })
+  electronDocs('76375a83eb3a97e7aed14d37d8bdc858c765e564').then(function (docs) {
+    t.comment('fetch by commit SHA')
+    var doc = docs[0]
+    t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
+  })
 
   electronDocs(path.join(__dirname, 'fixtures')).then(function (docs) {
-    t.comment('local directory')
+    t.comment('fetch from local directory')
     t.ok(docs.length > 0, 'docs is a non-empty array')
     t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
     t.ok(docs.every(doc => doc.slug.length > 0), 'every doc has a slug property')

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,12 @@ test('electronDocs', {timeout: 30 * 1000}, function (t) {
     t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
   })
 
+  // electronDocs('76375a83eb3a97e7aed14d37d8bdc858c765e564').then(function (docs) {
+  //   t.comment('commit SHA')
+  //   var doc = docs[0]
+  //   t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
+  // })
+
   electronDocs(path.join(__dirname, 'fixtures')).then(function (docs) {
     t.comment('local directory')
     t.ok(docs.length > 0, 'docs is a non-empty array')


### PR DESCRIPTION
The existing version only supports fetching docs by version or a local path.

This PR adds support for fetching docs by branch name or commit SHA.

I'm doing this so we can have more flexibility around importing fixture data into https://github.com/electron/electron-docs-linter. I want to drop the `electron/electron` git submodule there because it's huge (we just need the docs) and git submodules are a pain to work with.

Note: This is a breaking change to the API, as the version/branch/SHA/path argument is now required, and no longer defaults to hitting the GitHub API to fetch the latest release version.

cc @MarshallOfSound @kevinsawicki 