### PR TITLE
Use the OS specific path separator on windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function download (version, callback) {
   var tarball = path.join(tmpdir, `electron-${version}.tgz`)
 
   var extractor = tar.extract(tmpdir, {
-    ignore: (name) => { return !name.match('docs' + (process.platform === 'win32' ? '\\\\' : '/'))} }
+    ignore: (name) => { return !name.match(/[\\/]docs[\\/]/))} }
   )
     .on('entry', function extracting (header, stream, next) {
       if (!electronDir) {

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ function download (version, callback) {
   var tarball = path.join(tmpdir, `electron-${version}.tgz`)
 
   var extractor = tar.extract(tmpdir, {
-    ignore: (name) => { return !name.match(/[\\/]docs[\\/]/))} }
-  )
+    ignore: (name) => { return !name.match(/[\\/]docs[\\/]/) }
+  })
     .on('entry', function extracting (header, stream, next) {
       if (!electronDir) {
         electronDir = path.join(tmpdir, header.name.split('/')[0])

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function download (version, callback) {
   var tarball = path.join(tmpdir, `electron-${version}.tgz`)
 
   var extractor = tar.extract(tmpdir, {
-    ignore: (name) => { return !name.match('docs/')} }
+    ignore: (name) => { return !name.match('docs' + (process.platform === 'win32' ? '\\\\' : '/'))} }
   )
     .on('entry', function extracting (header, stream, next) {
       if (!electronDir) {


### PR DESCRIPTION
Fixes

```bash
node:38456) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error:
ENOENT: no such file or directory, scandir 'C:\Users\Samuel\AppData\Local\Temp\electron-master\docs\api'
```