### PR TITLE
remove leftover console log statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ function download (version, callback) {
       readFromDisk(path.join(electronDir, 'docs'), callback)
     })
 
-  console.log(`Downloading ${tarballUrl}`)
   got.stream(tarballUrl)
     .pipe(gunzip())
     .pipe(extractor)


### PR DESCRIPTION
Leave it to the consumer to log what they want..