### PR TITLE
Support leading v in version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Require the function and call it with any of the following:
 
 - A remote branch name, like `master`
 - A version number, like `1.4.4`
+- A version number that starts with a `v`, like `v1.7.0`
 - A commit SHA, like `76375a83eb3a97e7aed14d37d8bdc858c765e564`
 - A local directory, like `~/my/path/to/electron/`
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ function docs (input, callback) {
 }
 
 function download (version, callback) {
-  if (!!semver.valid(version)) version = `v${version}`
+  // Prepend `v` to 1.2.3
+  if (version.match(/^\d+\.\d+\.\d+$/)) version = `v${version}`
+
   var tarballUrl = `https://github.com/electron/electron/archive/${version}.tar.gz`
   var electronDir
   var tmpdir = require('os').tmpdir()

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const semver = require('semver')
 const electronDocs = require('..')
 
 test('electronDocs', {timeout: 30 * 1000}, function (t) {
-  t.plan(13)
+  t.plan(14)
 
   electronDocs('master').then(function (docs) {
     t.comment('fetch by branch name')
@@ -21,6 +21,12 @@ test('electronDocs', {timeout: 30 * 1000}, function (t) {
 
   electronDocs('1.2.0').then(function (docs) {
     t.comment('fetch by version number')
+    var doc = docs[0]
+    t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
+  })
+
+  electronDocs('v1.7.0').then(function (docs) {
+    t.comment('fetch by version number with leading v')
     var doc = docs[0]
     t.ok(docs.every(doc => doc.filename.length > 0), 'every doc has a filename property')
   })


### PR DESCRIPTION
Support leading `v` in version input, like `electronDocs('v1.2.3.')`. This makes it easier to use the `tag_name` values found in GitHub API responses.